### PR TITLE
C_GetAttributeValue and C_GenerateKeyPair attribute guessing

### DIFF
--- a/libsks/include/sks_ta.h
+++ b/libsks/include/sks_ta.h
@@ -715,7 +715,8 @@ struct sks_attribute_head {
 #define SKS_NOT_IMPLEMENTED			0x00001001
 
 /* Attribute specific values */
-#define SKS_UNDEFINED_ID			((uint32_t)0xFFFFFFFF)
+#define SKS_CK_UNAVAILABLE_INFORMATION		((uint32_t)0xFFFFFFFF)
+#define SKS_UNDEFINED_ID			SKS_CK_UNAVAILABLE_INFORMATION
 #define SKS_FALSE				0
 #define SKS_TRUE				1
 

--- a/libsks/include/sks_ta.h
+++ b/libsks/include/sks_ta.h
@@ -708,6 +708,7 @@ struct sks_attribute_head {
 #define SKS_CKR_USER_TYPE_INVALID		0x0000002a
 #define SKS_CKR_SESSION_READ_ONLY_EXISTS	0x0000002b
 #define SKS_CKR_KEY_SIZE_RANGE			0x0000002c
+#define SKS_CKR_ATTRIBUTE_SENSITIVE		0x0000002d
 
 /* Status without strict equivalence in Cryptoki API */
 #define SKS_NOT_FOUND				0x00001000

--- a/libsks/src/ck_helpers.h
+++ b/libsks/src/ck_helpers.h
@@ -100,8 +100,9 @@ int sks_class_has_type(uint32_t class);
  * Allocates memory for a copy of the attributes, since it could
  * become longer, that has to be freed by the caller.
  */
-void ck_guess_key_type(CK_MECHANISM_PTR mecha,
+CK_RV ck_guess_key_type(CK_MECHANISM_PTR mecha,
 		       CK_ATTRIBUTE_PTR attrs, CK_ULONG_PTR count,
-		       CK_ATTRIBUTE_PTR *attrs_new_p);
+		       CK_ATTRIBUTE_PTR *attrs_new_p,
+		       CK_KEY_TYPE_PTR *ckk_rsa);
 
 #endif /*__HELPERS_CK_H*/

--- a/libsks/src/ck_helpers.h
+++ b/libsks/src/ck_helpers.h
@@ -92,4 +92,16 @@ int ck_attr2boolprop_shift(CK_ULONG attr);
 int sks_object_has_boolprop(uint32_t class);
 int sks_class_has_type(uint32_t class);
 
+/*
+ * Try to guess key type if mechanism is key generation.
+ * This may be needed because some tools (e.g.: pkcs11-tool)
+ * don't seem specify some fields when those can be assumed 
+ * from the mechanism type.
+ * Allocates memory for a copy of the attributes, since it could
+ * become longer, that has to be freed by the caller.
+ */
+void ck_guess_key_type(CK_MECHANISM_PTR mecha,
+		       CK_ATTRIBUTE_PTR attrs, CK_ULONG_PTR count,
+		       CK_ATTRIBUTE_PTR *attrs_new_p);
+
 #endif /*__HELPERS_CK_H*/

--- a/libsks/src/pkcs11_api.c
+++ b/libsks/src/pkcs11_api.c
@@ -11,6 +11,7 @@
 #include "local_utils.h"
 #include "pkcs11_processing.h"
 #include "pkcs11_token.h"
+#include "ck_helpers.h"
 
 static int lib_inited;
 
@@ -38,16 +39,16 @@ static const CK_FUNCTION_LIST libsks_function_list = {
 	REGISTER_CK_FUNCTION(C_CloseSession),
 	REGISTER_CK_FUNCTION(C_CloseAllSessions),
 	REGISTER_CK_FUNCTION(C_GetSessionInfo),
-	DO_NOT_REGISTER_CK_FUNCTION(C_GetOperationState),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SetOperationState),
+	REGISTER_CK_FUNCTION(C_GetOperationState),
+	REGISTER_CK_FUNCTION(C_SetOperationState),
 	REGISTER_CK_FUNCTION(C_Login),
 	REGISTER_CK_FUNCTION(C_Logout),
 	REGISTER_CK_FUNCTION(C_CreateObject),
-	DO_NOT_REGISTER_CK_FUNCTION(C_CopyObject),
+	REGISTER_CK_FUNCTION(C_CopyObject),
 	REGISTER_CK_FUNCTION(C_DestroyObject),
-	DO_NOT_REGISTER_CK_FUNCTION(C_GetObjectSize),
-	DO_NOT_REGISTER_CK_FUNCTION(C_GetAttributeValue),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SetAttributeValue),
+	REGISTER_CK_FUNCTION(C_GetObjectSize),
+	REGISTER_CK_FUNCTION(C_GetAttributeValue),
+	REGISTER_CK_FUNCTION(C_SetAttributeValue),
 	REGISTER_CK_FUNCTION(C_FindObjectsInit),
 	REGISTER_CK_FUNCTION(C_FindObjects),
 	REGISTER_CK_FUNCTION(C_FindObjectsFinal),
@@ -59,37 +60,37 @@ static const CK_FUNCTION_LIST libsks_function_list = {
 	REGISTER_CK_FUNCTION(C_Decrypt),
 	REGISTER_CK_FUNCTION(C_DecryptUpdate),
 	REGISTER_CK_FUNCTION(C_DecryptFinal),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DigestInit),
-	DO_NOT_REGISTER_CK_FUNCTION(C_Digest),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DigestUpdate),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DigestKey),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DigestFinal),
+	REGISTER_CK_FUNCTION(C_DigestInit),
+	REGISTER_CK_FUNCTION(C_Digest),
+	REGISTER_CK_FUNCTION(C_DigestUpdate),
+	REGISTER_CK_FUNCTION(C_DigestKey),
+	REGISTER_CK_FUNCTION(C_DigestFinal),
 	REGISTER_CK_FUNCTION(C_SignInit),
 	REGISTER_CK_FUNCTION(C_Sign),
 	REGISTER_CK_FUNCTION(C_SignUpdate),
 	REGISTER_CK_FUNCTION(C_SignFinal),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SignRecoverInit),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SignRecover),
+	REGISTER_CK_FUNCTION(C_SignRecoverInit),
+	REGISTER_CK_FUNCTION(C_SignRecover),
 	REGISTER_CK_FUNCTION(C_VerifyInit),
 	REGISTER_CK_FUNCTION(C_Verify),
 	REGISTER_CK_FUNCTION(C_VerifyUpdate),
 	REGISTER_CK_FUNCTION(C_VerifyFinal),
-	DO_NOT_REGISTER_CK_FUNCTION(C_VerifyRecoverInit),
-	DO_NOT_REGISTER_CK_FUNCTION(C_VerifyRecover),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DigestEncryptUpdate),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DecryptDigestUpdate),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SignEncryptUpdate),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DecryptVerifyUpdate),
+	REGISTER_CK_FUNCTION(C_VerifyRecoverInit),
+	REGISTER_CK_FUNCTION(C_VerifyRecover),
+	REGISTER_CK_FUNCTION(C_DigestEncryptUpdate),
+	REGISTER_CK_FUNCTION(C_DecryptDigestUpdate),
+	REGISTER_CK_FUNCTION(C_SignEncryptUpdate),
+	REGISTER_CK_FUNCTION(C_DecryptVerifyUpdate),
 	REGISTER_CK_FUNCTION(C_GenerateKey),
 	REGISTER_CK_FUNCTION(C_GenerateKeyPair),
-	DO_NOT_REGISTER_CK_FUNCTION(C_WrapKey),
-	DO_NOT_REGISTER_CK_FUNCTION(C_UnwrapKey),
-	DO_NOT_REGISTER_CK_FUNCTION(C_DeriveKey),
-	DO_NOT_REGISTER_CK_FUNCTION(C_SeedRandom),
-	DO_NOT_REGISTER_CK_FUNCTION(C_GenerateRandom),
-	DO_NOT_REGISTER_CK_FUNCTION(C_GetFunctionStatus),
-	DO_NOT_REGISTER_CK_FUNCTION(C_CancelFunction),
-	DO_NOT_REGISTER_CK_FUNCTION(C_WaitForSlotEvent),
+	REGISTER_CK_FUNCTION(C_WrapKey),
+	REGISTER_CK_FUNCTION(C_UnwrapKey),
+	REGISTER_CK_FUNCTION(C_DeriveKey),
+	REGISTER_CK_FUNCTION(C_SeedRandom),
+	REGISTER_CK_FUNCTION(C_GenerateRandom),
+	REGISTER_CK_FUNCTION(C_GetFunctionStatus),
+	REGISTER_CK_FUNCTION(C_CancelFunction),
+	REGISTER_CK_FUNCTION(C_WaitForSlotEvent),
 };
 
 /*
@@ -745,15 +746,35 @@ CK_RV C_GetAttributeValue(CK_SESSION_HANDLE session,
 			  CK_ATTRIBUTE_PTR attribs,
 			  CK_ULONG count)
 {
-	(void)session;
-	(void)obj;
-	(void)attribs;
-	(void)count;
+	CK_RV rv;
 
 	if (!lib_inited)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	rv = ck_get_attribute_value(session, obj, attribs, count);
+
+	switch (rv) {
+	case CKR_ARGUMENTS_BAD:
+	case CKR_ATTRIBUTE_TYPE_INVALID:
+	case CKR_ATTRIBUTE_VALUE_INVALID:
+	case CKR_CRYPTOKI_NOT_INITIALIZED:
+	case CKR_DEVICE_ERROR:
+	case CKR_DEVICE_MEMORY:
+	case CKR_DEVICE_REMOVED:
+	case CKR_FUNCTION_FAILED:
+	case CKR_GENERAL_ERROR:
+	case CKR_HOST_MEMORY:
+	case CKR_OK:
+	case CKR_OPERATION_ACTIVE:
+	case CKR_PIN_EXPIRED:
+	case CKR_SESSION_CLOSED:
+	case CKR_SESSION_HANDLE_INVALID:
+		break;
+	default:
+		assert(!rv);
+	}
+
+	return rv;
 }
 
 CK_RV C_SetAttributeValue(CK_SESSION_HANDLE session,
@@ -1742,12 +1763,22 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE session,
 			CK_OBJECT_HANDLE_PTR priv_key)
 {
 	CK_RV rv;
+	CK_ATTRIBUTE_PTR pub_attribs_n=0;
+	CK_ATTRIBUTE_PTR priv_attribs_n=0;
 
 	if (!lib_inited)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	
+	ck_guess_key_type(mechanism, pub_attribs, &pub_count, &pub_attribs_n);	
+	ck_guess_key_type(mechanism, priv_attribs, &priv_count, &priv_attribs_n);	
+	if (!pub_attribs_n || !priv_attribs_n)
+		return CKR_TEMPLATE_INCOMPLETE;
 
-	rv = ck_generate_key_pair(session, mechanism, pub_attribs, pub_count,
-				  priv_attribs, priv_count, pub_key, priv_key);
+	rv = ck_generate_key_pair(session, mechanism, pub_attribs_n, pub_count,
+				  priv_attribs_n, priv_count, pub_key, priv_key);
+
+	free(pub_attribs_n);
+	free(priv_attribs_n);
 
 	switch (rv) {
 	case CKR_ARGUMENTS_BAD:

--- a/libsks/src/pkcs11_api.c
+++ b/libsks/src/pkcs11_api.c
@@ -19,10 +19,10 @@ static int lib_inited;
 #define DO_NOT_REGISTER_CK_FUNCTION(_function)	._function = NULL
 
 static const CK_FUNCTION_LIST libsks_function_list = {
-    .version = {
-        .major = 2,
-        .minor = 40,
-    },
+	.version = {
+		.major = 2,
+		.minor = 40,
+	},
 	REGISTER_CK_FUNCTION(C_Initialize),
 	REGISTER_CK_FUNCTION(C_Finalize),
 	REGISTER_CK_FUNCTION(C_GetInfo),
@@ -39,16 +39,16 @@ static const CK_FUNCTION_LIST libsks_function_list = {
 	REGISTER_CK_FUNCTION(C_CloseSession),
 	REGISTER_CK_FUNCTION(C_CloseAllSessions),
 	REGISTER_CK_FUNCTION(C_GetSessionInfo),
-	REGISTER_CK_FUNCTION(C_GetOperationState),
-	REGISTER_CK_FUNCTION(C_SetOperationState),
+	DO_NOT_REGISTER_CK_FUNCTION(C_GetOperationState),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SetOperationState),
 	REGISTER_CK_FUNCTION(C_Login),
 	REGISTER_CK_FUNCTION(C_Logout),
 	REGISTER_CK_FUNCTION(C_CreateObject),
-	REGISTER_CK_FUNCTION(C_CopyObject),
+	DO_NOT_REGISTER_CK_FUNCTION(C_CopyObject),
 	REGISTER_CK_FUNCTION(C_DestroyObject),
-	REGISTER_CK_FUNCTION(C_GetObjectSize),
+	DO_NOT_REGISTER_CK_FUNCTION(C_GetObjectSize),
 	REGISTER_CK_FUNCTION(C_GetAttributeValue),
-	REGISTER_CK_FUNCTION(C_SetAttributeValue),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SetAttributeValue),
 	REGISTER_CK_FUNCTION(C_FindObjectsInit),
 	REGISTER_CK_FUNCTION(C_FindObjects),
 	REGISTER_CK_FUNCTION(C_FindObjectsFinal),
@@ -60,37 +60,37 @@ static const CK_FUNCTION_LIST libsks_function_list = {
 	REGISTER_CK_FUNCTION(C_Decrypt),
 	REGISTER_CK_FUNCTION(C_DecryptUpdate),
 	REGISTER_CK_FUNCTION(C_DecryptFinal),
-	REGISTER_CK_FUNCTION(C_DigestInit),
-	REGISTER_CK_FUNCTION(C_Digest),
-	REGISTER_CK_FUNCTION(C_DigestUpdate),
-	REGISTER_CK_FUNCTION(C_DigestKey),
-	REGISTER_CK_FUNCTION(C_DigestFinal),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DigestInit),
+	DO_NOT_REGISTER_CK_FUNCTION(C_Digest),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DigestUpdate),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DigestKey),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DigestFinal),
 	REGISTER_CK_FUNCTION(C_SignInit),
 	REGISTER_CK_FUNCTION(C_Sign),
 	REGISTER_CK_FUNCTION(C_SignUpdate),
 	REGISTER_CK_FUNCTION(C_SignFinal),
-	REGISTER_CK_FUNCTION(C_SignRecoverInit),
-	REGISTER_CK_FUNCTION(C_SignRecover),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SignRecoverInit),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SignRecover),
 	REGISTER_CK_FUNCTION(C_VerifyInit),
 	REGISTER_CK_FUNCTION(C_Verify),
 	REGISTER_CK_FUNCTION(C_VerifyUpdate),
 	REGISTER_CK_FUNCTION(C_VerifyFinal),
-	REGISTER_CK_FUNCTION(C_VerifyRecoverInit),
-	REGISTER_CK_FUNCTION(C_VerifyRecover),
-	REGISTER_CK_FUNCTION(C_DigestEncryptUpdate),
-	REGISTER_CK_FUNCTION(C_DecryptDigestUpdate),
-	REGISTER_CK_FUNCTION(C_SignEncryptUpdate),
-	REGISTER_CK_FUNCTION(C_DecryptVerifyUpdate),
+	DO_NOT_REGISTER_CK_FUNCTION(C_VerifyRecoverInit),
+	DO_NOT_REGISTER_CK_FUNCTION(C_VerifyRecover),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DigestEncryptUpdate),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DecryptDigestUpdate),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SignEncryptUpdate),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DecryptVerifyUpdate),
 	REGISTER_CK_FUNCTION(C_GenerateKey),
 	REGISTER_CK_FUNCTION(C_GenerateKeyPair),
-	REGISTER_CK_FUNCTION(C_WrapKey),
-	REGISTER_CK_FUNCTION(C_UnwrapKey),
-	REGISTER_CK_FUNCTION(C_DeriveKey),
-	REGISTER_CK_FUNCTION(C_SeedRandom),
-	REGISTER_CK_FUNCTION(C_GenerateRandom),
-	REGISTER_CK_FUNCTION(C_GetFunctionStatus),
-	REGISTER_CK_FUNCTION(C_CancelFunction),
-	REGISTER_CK_FUNCTION(C_WaitForSlotEvent),
+	DO_NOT_REGISTER_CK_FUNCTION(C_WrapKey),
+	DO_NOT_REGISTER_CK_FUNCTION(C_UnwrapKey),
+	DO_NOT_REGISTER_CK_FUNCTION(C_DeriveKey),
+	DO_NOT_REGISTER_CK_FUNCTION(C_SeedRandom),
+	DO_NOT_REGISTER_CK_FUNCTION(C_GenerateRandom),
+	DO_NOT_REGISTER_CK_FUNCTION(C_GetFunctionStatus),
+	DO_NOT_REGISTER_CK_FUNCTION(C_CancelFunction),
+	DO_NOT_REGISTER_CK_FUNCTION(C_WaitForSlotEvent),
 };
 
 /*
@@ -1763,22 +1763,25 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE session,
 			CK_OBJECT_HANDLE_PTR priv_key)
 {
 	CK_RV rv;
-	CK_ATTRIBUTE_PTR pub_attribs_n=0;
-	CK_ATTRIBUTE_PTR priv_attribs_n=0;
+	CK_ATTRIBUTE_PTR pub_attribs_n = 0;
+	CK_ATTRIBUTE_PTR priv_attribs_n = 0;
+	CK_KEY_TYPE_PTR ckk1 = 0;
+	CK_KEY_TYPE_PTR ckk2 = 0;
 
 	if (!lib_inited)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;
 	
-	ck_guess_key_type(mechanism, pub_attribs, &pub_count, &pub_attribs_n);	
-	ck_guess_key_type(mechanism, priv_attribs, &priv_count, &priv_attribs_n);	
-	if (!pub_attribs_n || !priv_attribs_n)
-		return CKR_TEMPLATE_INCOMPLETE;
+	rv = ck_guess_key_type(mechanism, pub_attribs, &pub_count,
+			       &pub_attribs_n, &ckk1);	
+	if (rv != CKR_OK)
+		goto bail;
+	rv = ck_guess_key_type(mechanism, priv_attribs, &priv_count,
+			       &priv_attribs_n, &ckk2);	
+	if (rv != CKR_OK)
+		goto bail;
 
 	rv = ck_generate_key_pair(session, mechanism, pub_attribs_n, pub_count,
 				  priv_attribs_n, priv_count, pub_key, priv_key);
-
-	free(pub_attribs_n);
-	free(priv_attribs_n);
 
 	switch (rv) {
 	case CKR_ARGUMENTS_BAD:
@@ -1811,6 +1814,16 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE session,
 	default:
 		assert(!rv);
 	}
+
+bail:
+	if (pub_attribs_n)
+		free(pub_attribs_n);
+	if (priv_attribs_n)
+		free(priv_attribs_n);
+	if (ckk1)
+		free(ckk1);
+	if (ckk2)
+		free(ckk2);
 
 	return rv;
 }

--- a/libsks/src/pkcs11_processing.c
+++ b/libsks/src/pkcs11_processing.c
@@ -296,7 +296,6 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 	if (rv)
 		goto bail;
 
-
 	/* ctrl = [session-handle][serial-mecha][serial-pub][serial-priv] */
 	ctrl_size = sizeof(uint32_t) + smecha.size + pub_sattr.size +
 			priv_sattr.size;
@@ -305,7 +304,7 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 		rv = CKR_HOST_MEMORY;
 		goto bail;
 	}
-
+	
 	memcpy(ctrl, &session_handle, sizeof(uint32_t));
 	memcpy(ctrl + sizeof(uint32_t),
 		smecha.buffer, smecha.size);
@@ -322,7 +321,7 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 		rv = CKR_GENERAL_ERROR;
 	if (rv)
 		goto bail;
-
+	
 	*pub_key = key_handle[0];
 	*priv_key = key_handle[1];
 
@@ -599,6 +598,57 @@ CK_RV ck_derive_key(CK_SESSION_HANDLE session,
 bail:
 	free(ctrl);
 	release_serial_object(&smecha);
+	release_serial_object(&sattr);
+	return rv;
+}
+
+CK_RV ck_get_attribute_value(CK_SESSION_HANDLE session,
+			     CK_OBJECT_HANDLE obj,
+			     CK_ATTRIBUTE_PTR attribs,
+			     CK_ULONG count) {
+	CK_RV rv;
+	struct serializer sattr;
+	uint32_t session_handle = session;
+	char *ctrl = NULL;
+	size_t ctrl_size;
+	char *out = NULL;
+	size_t out_size;
+	uint32_t obj_handle = obj;
+	size_t obj_handle_size = sizeof(obj_handle);
+
+	rv = serialize_ck_attributes(&sattr, attribs, count);
+	if (rv)
+		goto bail;
+
+	/* ctrl = [session][obj-handle][attributes] */
+	ctrl_size = sizeof(uint32_t) + obj_handle_size + sattr.size;
+	ctrl = malloc(ctrl_size);
+	if (!ctrl) {
+		rv = CKR_HOST_MEMORY;
+		goto bail;
+	}
+	/* out = [attributes] */
+	out_size = sattr.size;
+	out = malloc(out_size);
+	if (!out){
+		rv = CKR_HOST_MEMORY;
+		goto bail;
+	}
+
+	memcpy(ctrl, &session_handle, sizeof(uint32_t));
+	memcpy(ctrl + sizeof(uint32_t),
+			&obj_handle, sizeof(uint32_t));
+	memcpy(ctrl + sizeof(uint32_t) + obj_handle_size,
+			sattr.buffer, sattr.size);
+
+	rv = ck_invoke_ta_in_out(ck_session2sks_ctx(session),
+				 SKS_CMD_GET_ATTRIBUTE_VALUE, ctrl, ctrl_size,
+				 NULL, 0, out, &out_size);
+
+	rv = deserialize_ck_attributes(out, attribs, count);
+
+bail:
+	free(ctrl);
 	release_serial_object(&sattr);
 	return rv;
 }

--- a/libsks/src/pkcs11_processing.c
+++ b/libsks/src/pkcs11_processing.c
@@ -304,7 +304,7 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 		rv = CKR_HOST_MEMORY;
 		goto bail;
 	}
-	
+
 	memcpy(ctrl, &session_handle, sizeof(uint32_t));
 	memcpy(ctrl + sizeof(uint32_t),
 		smecha.buffer, smecha.size);
@@ -321,7 +321,7 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 		rv = CKR_GENERAL_ERROR;
 	if (rv)
 		goto bail;
-	
+
 	*pub_key = key_handle[0];
 	*priv_key = key_handle[1];
 

--- a/libsks/src/pkcs11_processing.h
+++ b/libsks/src/pkcs11_processing.h
@@ -96,4 +96,9 @@ CK_RV ck_derive_key(CK_SESSION_HANDLE session,
 		    CK_ULONG count,
 		    CK_OBJECT_HANDLE_PTR key_handle);
 
+CK_RV ck_get_attribute_value(CK_SESSION_HANDLE session,
+			     CK_OBJECT_HANDLE obj,
+			     CK_ATTRIBUTE_PTR attribs,
+			     CK_ULONG count);
+
 #endif /*__PKCS11_PROCESSING_H*/

--- a/libsks/src/serialize_ck.c
+++ b/libsks/src/serialize_ck.c
@@ -483,10 +483,7 @@ out:
 	return rv;
 }
 
-CK_RV deserialize_ck_attribute(struct sks_attribute_head *in,
-			       CK_ATTRIBUTE_PTR out);
-
-CK_RV deserialize_ck_attribute(struct sks_attribute_head *in,
+static CK_RV deserialize_ck_attribute(struct sks_attribute_head *in,
 			       CK_ATTRIBUTE_PTR out)
 {
 	CK_ULONG ck_ulong;

--- a/libsks/src/serialize_ck.h
+++ b/libsks/src/serialize_ck.h
@@ -14,6 +14,10 @@
 CK_RV serialize_ck_attributes(struct serializer *obj,
 				CK_ATTRIBUTE_PTR attributes, CK_ULONG count);
 
+/* Convert SKS attributes back to CK_ATTRIBUTE array */
+CK_RV deserialize_ck_attributes(void *in, CK_ATTRIBUTE_PTR attributes,
+					  CK_ULONG count);
+
 /* Create (and allocate) a serial object for CK_MECHANISM array */
 CK_RV serialize_ck_mecha_params(struct serializer *obj,
 				CK_MECHANISM_PTR mechanisms);


### PR DESCRIPTION
Signed-off-by: Gabor Szekely <szvgabor@gmail.com>

- Added first implementation of C_GetAttributeValue, for this I
implemented a deserialize_ck_attribute function, however some
cases are not handled there. The return values are also not
always correct. I will deal with these issues later.

- Added key type guessing to C_GenerateKeyPair, since the PKCS11
standard states that in cases when the key type is deducable from
the key generation mechanism, it is not required to specify it.
For now, only one type of key is guessed, but more can be added
later, and the same guessing should be done in C_GenerateKey