### PR TITLE
libsks: link against libteec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-tee-supplicant: build-libteec
 
 build: build-libteec build-tee-supplicant build-libsks
 
-build-libsks:
+build-libsks: build-libteec
 	@echo "Building libsks.so"
 	@$(MAKE) --directory=libsks --no-print-directory --no-builtin-variables
 

--- a/libsks/Makefile
+++ b/libsks/Makefile
@@ -34,6 +34,8 @@ LIBSKS_INCLUDES 	+= ${CURDIR}/../public
 LIBSKS_CFLAGS		:= $(addprefix -I, $(LIBSKS_INCLUDES)) \
 				$(CFLAGS) -D_GNU_SOURCE -fPIC
 
+LIBSKS_LFLAGS		:= $(LDFLAGS) -L$(OUT_DIR)/../libteec -lteec
+
 LIBSKS_OBJ_DIR		:= $(OUT_DIR)
 LIBSKS_OBJS		:= $(patsubst %.c,$(LIBSKS_OBJ_DIR)/%.o, $(LIBSKS_SRCS))
 
@@ -46,7 +48,7 @@ libsks: $(OUT_DIR)/$(LIBSKS_SO_LIBRARY)
 
 $(OUT_DIR)/$(LIBSKS_SO_LIBRARY): $(LIBSKS_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIBSKS_SO_LIBRARY) $(LIBSKS_LFLAGS) -o $@ $+
+	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIBSKS_SO_LIBRARY) -o $@ $+ $(LIBSKS_LFLAGS)
 	@echo ""
 
 libsks: $(OUT_DIR)/$(LIBSKS_AR_LIBRARY)


### PR DESCRIPTION
Previously libsks was not linked dynamically against libteec.
This was not noticed because the xtest application is linked against both
libraries and the symbols could be resolved during runtime.

However loading libsks as a standalone pkcs#11 library failed because of the
missing dynamic linking information.
Add libteec as a dynamic link dependency and depend the build-libsks target on
the build-libteec target.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>