### PR TITLE
sks: serializer: fix to treat CKA_MODULUS_BITS as a CK_ULONG

### DIFF
--- a/libsks/src/serialize_ck.c
+++ b/libsks/src/serialize_ck.c
@@ -170,9 +170,16 @@ static CK_RV deserialize_indirect_attribute(struct sks_attribute_head *obj,
 
 static int ck_attr_is_ulong(CK_ATTRIBUTE_TYPE attribute_id)
 {
-	return (ck_attr_is_class(attribute_id) ||
-		ck_attr_is_type(attribute_id) ||
-		attribute_id == CKA_VALUE_LEN);
+	if (ck_attr_is_class(attribute_id) || ck_attr_is_type(attribute_id))
+		return true;
+
+	switch (attribute_id) {
+	case CKA_VALUE_LEN:
+	case CKA_MODULUS_BITS:
+		return true;
+	default:
+		return false;
+	}
 }
 
 static CK_RV serialize_ck_attribute(struct serializer *obj, CK_ATTRIBUTE *attr)


### PR DESCRIPTION
As per PKCS#11 specification, CKA_MODULUS_BITS is a CK_ULONG typed
value hence shall be properly converted as a SKS ulong value. This
change correct libsks to properly handle the conversion.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>