### PR TITLE
libsks: add support for CKM_EC_KEY_PAIR_GEN

### DIFF
--- a/libsks/src/ck_helpers.c
+++ b/libsks/src/ck_helpers.c
@@ -744,6 +744,13 @@ CK_RV ck_guess_key_type(CK_MECHANISM_PTR mecha,
 		attrs_new[count_new - 1].ulValueLen = sizeof(CK_KEY_TYPE);
 		rv = CKR_OK;
 		break;
+	case CKM_EC_KEY_PAIR_GEN:
+		*key_type_p = CKK_EC;
+		attrs_new[count_new - 1].type = CKA_KEY_TYPE;
+		attrs_new[count_new - 1].pValue = key_type_p;
+		attrs_new[count_new - 1].ulValueLen = sizeof(CK_KEY_TYPE);
+		rv = CKR_OK;
+		break;
 	default:
 		rv = CKR_TEMPLATE_INCOMPLETE;
 		break;


### PR DESCRIPTION
Add matching EC key type for CKM_EC_KEY_PAIR_GEN.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>