### PR TITLE
libsks: fix ABI for TA command VERIFY_FINAL

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -685,7 +685,7 @@ CK_RV ck_signverify_final(CK_SESSION_HANDLE session,
 	TEEC_SharedMemory *ctrl = NULL;
 	TEEC_SharedMemory *io = NULL;
 	uint32_t session_handle = session;
-	size_t out_size = 0;
+	size_t io_size = 0;
 
 	if ((sign_len && *sign_len && !sign_ref) || (sign && !sign_len))
 		return CKR_ARGUMENTS_BAD;
@@ -714,16 +714,14 @@ CK_RV ck_signverify_final(CK_SESSION_HANDLE session,
 		goto bail;
 	}
 
-	if (sign)
-		rv = ckteec_invoke_ctrl_out(PKCS11_CMD_SIGN_FINAL, ctrl, io,
-					    &out_size);
-	else
-		rv = ckteec_invoke_ctrl_in(PKCS11_CMD_VERIFY_FINAL, ctrl, io);
+	rv = ckteec_invoke_ta(sign ? PKCS11_CMD_SIGN_FINAL :
+			      PKCS11_CMD_VERIFY_FINAL, ctrl, NULL, io,
+			      &io_size, NULL, NULL);
 
 	if (sign && sign_len && (rv == CKR_OK || rv == CKR_BUFFER_TOO_SMALL))
-		*sign_len = out_size;
+		*sign_len = io_size;
 
-	if (rv == CKR_BUFFER_TOO_SMALL && out_size && !sign_ref)
+	if (rv == CKR_BUFFER_TOO_SMALL && io_size && !sign_ref)
 		rv = CKR_OK;
 
 bail:


### PR DESCRIPTION
This change fixes ck_signverify_final() to use helper ckteec_invoke_ta()
rather than ckteec_invoke_crtl_in/_out() as the memref argument @io
is passed through memref param#2 for both SIGN_FINAL and VERIFY_FINAL
in the mainline PKCS11 TA [1] (which we synced with). In our SKS TA
implementation, VERIFY_FINAL command used to pass @io through
memref param#1.

This change renames local variable out_size to io_size for consistency.

Tested (full non-regression) with pkcs11 TA built from [2] and xtest [3].

Link: [1] https://github.com/OP-TEE/optee_os/commit/58ab0c3d6c72
Link: [2] https://github.com/etienne-lms/optee_os/commit/40c3a974f2ca
Link: [3] https://github.com/etienne-lms/optee_test/commit/f849cf1d626d
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>